### PR TITLE
Support custom tracking data

### DIFF
--- a/lib/Event.js
+++ b/lib/Event.js
@@ -1,25 +1,25 @@
 var config = require('../config');
 
-var Event = module.exports = function(GS, name, data) {
+var Event = module.exports = function(GS, name, data, trackingData) {
   this.GS = GS;
 
-  this.body = {
-    event: {
-      name: name,
-      data: data || {}
-    }
-  };
+  this.name = name;
+  this.data = data || {};
+  this.trackingData = trackingData || {};
 };
 
 Event.prototype.track = function(cb) {
-  cb = cb || function() {};
+  if (!cb) cb = function() {};
 
-  if (!this.body.event.name){
-    return cb && cb(new Error('Event name not given'));
+  if (!this.name){
+    return cb(new Error('Event name not given'));
   }
 
-  this.body.person_id = this.personID;
-  this.body.visitor_id = this.anonymousID;
+  var body = trackingData;
+  body.event = {
+    name: this.name,
+    data: this.data
+  };
 
-  this.GS._exec(config.endpoint + '/tracking/v1', '/event', 'POST', {}, this.body, cb);
+  this.GS._exec(config.endpoint + '/tracking/v1', '/event', 'POST', {}, body, cb);
 };

--- a/lib/Event.js
+++ b/lib/Event.js
@@ -15,7 +15,7 @@ Event.prototype.track = function(cb) {
     return cb(new Error('Event name not given'));
   }
 
-  var body = trackingData;
+  var body = this.trackingData;
   body.event = {
     name: this.name,
     data: this.data

--- a/lib/Person.js
+++ b/lib/Person.js
@@ -38,8 +38,7 @@ var Person = module.exports = function(GS, id) {
 };
 
 Person.prototype._exec = function(url, params, data, cb) {
-  var GS = this.GS;
-  GS._exec(config.endpoint + '/tracking/v1', url, 'POST', params, data, cb);
+  this.GS._exec(config.endpoint + '/tracking/v1', url, 'POST', params, this._addIDs(data), cb);
 };
 
 Person.prototype._verifyID = function(cb) {
@@ -53,6 +52,13 @@ Person.prototype._verifyID = function(cb) {
   return true;
 };
 
+Person.prototype._addIDs = function(trackingData) {
+  if (!trackingData) trackingData = {};
+  trackingData.person_id = this.id;
+  trackingData.visitor_id = this.anonymousID;
+  return trackingData;
+}
+
 // identify is very similar to setProperties but requires an identifying property (id or email)
 Person.prototype.identify = function(props, cb) {
   this.id = props;
@@ -64,11 +70,7 @@ Person.prototype.identify = function(props, cb) {
     return;
   }
 
-  this._exec('/identify', {}, {
-    visitor_id: this.anonymousID,
-    person_id: this.id,
-    properties: props
-  }, cb);
+  this._exec('/identify', {}, { properties: props }, cb);
 };
 
 Person.prototype.setProperties = function(props, cb) {
@@ -76,35 +78,32 @@ Person.prototype.setProperties = function(props, cb) {
 
   if (!this._verifyID(cb)) return;
 
-  this._exec('/properties', {}, {
-    visitor_id: this.anonymousID,
-    person_id: this.id,
-    properties: props
-  }, cb);
+  this._exec('/properties', {}, { properties: props }, cb);
 };
 
-Person.prototype.trackEvent = function(name, data, cb) {
-  if (typeof data === 'function') {
+Person.prototype.trackEvent = function(name, data, trackingData, cb) {
+  if (!cb && !trackingData && typeof data === 'function') {
     cb = data;
     data = {};
+    trackingData = {};
+  }
+
+  if (!cb && typeof trackingData === 'function') {
+    cb = trackingData;
+    trackingData = {};
   }
 
   if (!this._verifyID(cb)) return;
 
-  var event = new Event(this.GS, name, data);
-  event.personID = this.id;
-  event.anonymousID = this.anonymousID;
+  var event = new Event(this.GS, name, data, this._addIDs(trackingData));
   event.track(cb);
 };
 
-Person.prototype.createTransaction = function(transactionID, opts) {
+Person.prototype.createTransaction = function(transactionID, opts, trackingData) {
   // not too sure how to nicely error here if theres no ID.
   // the transaction will work, but won't be associated with a person
   // should we throw?
   // if (!this._verifyID(cb)) return;
 
-  var t = new Transaction(this.GS, transactionID, opts);
-  t.personID = this.id;
-  t.anonymousID = this.anonymousID;
-  return t;
+  return new Transaction(this.GS, transactionID, opts, this._addIDs(trackingData));
 };

--- a/lib/Transaction.js
+++ b/lib/Transaction.js
@@ -1,26 +1,23 @@
 var utils = require('./utils');
 var config = require('../config');
 
-var Transaction = module.exports = function(GS, transactionID, opts){
+var Transaction = module.exports = function(GS, transactionID, opts, trackingData){
   this.GS = GS;
   this.id = transactionID;
   this.items = [];
 
-  if (typeof transactionID === 'object') {
+  if (transactionID && typeof transactionID === 'object') {
     opts = transactionID;
     this.id = transactionID.id;
   }
 
-  if (typeof opts === 'object') {
-    this.opts = opts;
-  } else {
-    this.opts = {};
-  }
+  this.opts = opts || {};
+  this.trackingData = trackingData || {}
 };
 
 Transaction.prototype.addItem = function(itemName, itemOpts) {
   itemOpts = itemOpts || (typeof itemName === 'object' ? itemName : {});
-  if(typeof itemName !== 'object' && typeof itemName !== 'undefined') itemOpts.name = '' + itemName;
+  if (typeof itemName !== 'object' && typeof itemName !== 'undefined') itemOpts.name = itemName + '';
 
   this.items.push(itemOpts);
 };
@@ -33,14 +30,14 @@ Transaction.prototype.addItems = function(items) {
 };
 
 Transaction.prototype.track = function(cb){
-  var GS = this.GS, err;
+  var GS = this.GS;
 
-  if(typeof cb !== 'function'){
+  if (typeof cb !== 'function'){
     cb = function(){};
   }
 
   if (typeof this.id === 'undefined') {
-    err = new Error('Transaction ID not given');
+    var err = new Error('Transaction ID not given');
     err.transaction = this;
     return cb(err);
   }
@@ -48,21 +45,20 @@ Transaction.prototype.track = function(cb){
   for (var i = 0; i < this.items.length; i++) {
     var it = this.items[i];
     if (!it.name) {
-      err = new Error('Item name not given');
+      var err = new Error('Item name not given');
       err.item = it;
       err.transaction = this;
       return cb(err);
     }
   }
 
-  var body = {
-    person_id: this.personID,
-    visitor_id: this.anonymousID,
-    transaction: {
-      id: this.id,
-      items: this.items,
-      opts: this.opts
-    }
+
+
+  var body = this.trackingData;
+  body.transaction = {
+    id: this.id,
+    items: this.items,
+    opts: this.opts
   };
 
   GS._exec(config.endpoint + '/tracking/v1', '/transaction', 'POST', {}, body, cb);

--- a/lib/api/Tracking.js
+++ b/lib/api/Tracking.js
@@ -12,20 +12,26 @@ var Tracking = module.exports = function(GS) {
   }
 };
 
-Tracking.prototype.createTransaction = function(transactionID, opts){
-  return new Transaction(this.GS, transactionID, opts);
+Tracking.prototype.createTransaction = function(transactionID, opts, trackingData){
+  return new Transaction(this.GS, transactionID, opts, trackingData);
 };
 
 Tracking.prototype.createPerson = function(id){
   return new Person(this.GS, id);
 };
 
-Tracking.prototype.trackEvent = function(name, data, cb) {
-  if (typeof data === 'function') {
+Tracking.prototype.trackEvent = function(name, data, trackingData, cb) {
+  if (!cb && !trackingData && typeof data === 'function') {
     cb = data;
     data = {};
+    trackingData = {};
   }
 
-  var event = new Event(this.GS, name, data);
+  if (!cb && typeof trackingData === 'function') {
+    cb = trackingData;
+    trackingData = {};
+  }
+
+  var event = new Event(this.GS, name, data, trackingData);
   event.track(cb);
 };


### PR DESCRIPTION
Minor version bump needed.

Allows usage such as...

``` js
var t = gosquared.createTransaction(1, { revenue: 100 }, { ip: '192.168.1.1' });
t.track(console.log);
```
